### PR TITLE
Handle Codebook_Mnemonic values and update to 1.1.delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Introduction
 `bin/ons_csv_to_ctb_json_main.py` is an application that loads source metadata files in CSV format
 and converts them to hierarchical JSON that can be loaded into `cantabular-metadata`.
 
-It is compatible with version `1.1` of the metadata schema and versions `9.3.0`/`9.2.0` of
-`cantabular-metadata`. `9.3.0` format is used by default.
+It is compatible with version `1.1` of the metadata schema and versions `10.0.0`/`9.3.0`/`9.2.0` of
+`cantabular-metadata`. `10.0.0` format is used by default and is identical to the `9.3.0` format.
 
-This is version `1.1.gamma` of the CSV to JSON processing software and is subject to change.
+This is version `1.1.delta` of the CSV to JSON processing software and is subject to change.
 
 The applications only use packages in the Python standard library.
 
@@ -35,56 +35,56 @@ Basic logging will be displayed by default, including the number of high-level C
 objects loaded and the name of the output files.
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/ -g test/testdata/geography/geography.csv -o ctb_metadata_files/
-t=2022-05-09 21:26:50,348 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.gamma
-t=2022-05-09 21:26:50,348 lvl=INFO msg=CSV source directory: test/testdata/
-t=2022-05-09 21:26:50,348 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
-t=2022-05-09 21:26:50,350 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
-t=2022-05-09 21:26:50,350 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
-t=2022-05-09 21:26:50,350 lvl=INFO msg=Dropped non public classification: GEO_PRIV
-t=2022-05-09 21:26:50,350 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
-t=2022-05-09 21:26:50,351 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
-t=2022-05-09 21:26:50,351 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
-t=2022-05-09 21:26:50,351 lvl=INFO msg=Loaded metadata for 4 Cantabular tables
-t=2022-05-09 21:26:50,351 lvl=INFO msg=Loaded service metadata
-t=2022-05-09 21:26:50,351 lvl=INFO msg=Output files will be written in Cantabular 9.3.0 format
-t=2022-05-09 21:26:50,352 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v9-3-0_unknown-metadata-version_dataset-md_20220509-1.json
-t=2022-05-09 21:26:50,353 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v9-3-0_unknown-metadata-version_tables-md_20220509-1.json
-t=2022-05-09 21:26:50,353 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v9-3-0_unknown-metadata-version_service-md_20220509-1.json
+t=2022-05-24 16:40:14,151 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.delta
+t=2022-05-24 16:40:14,151 lvl=INFO msg=CSV source directory: test/testdata/
+t=2022-05-24 16:40:14,151 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
+t=2022-05-24 16:40:14,153 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
+t=2022-05-24 16:40:14,153 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
+t=2022-05-24 16:40:14,153 lvl=INFO msg=Dropped non public classification: GEO_PRIV
+t=2022-05-24 16:40:14,153 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
+t=2022-05-24 16:40:14,153 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
+t=2022-05-24 16:40:14,154 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
+t=2022-05-24 16:40:14,154 lvl=INFO msg=Loaded metadata for 4 Cantabular tables
+t=2022-05-24 16:40:14,154 lvl=INFO msg=Loaded service metadata
+t=2022-05-24 16:40:14,154 lvl=INFO msg=Output files will be written in Cantabular 10.0.0 format
+t=2022-05-24 16:40:14,156 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-0-0_unknown-metadata-version_dataset-md_20220524-1.json
+t=2022-05-24 16:40:14,156 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-0-0_unknown-metadata-version_tables-md_20220524-1.json
+t=2022-05-24 16:40:14,156 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-0-0_unknown-metadata-version_service-md_20220524-1.json
 ```
 
 More detailed information can be obtained by running with a `-l DEBUG` flag e.g.:
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/ -g test/testdata/geography/geography.csv -o ctb_metadata_files/ -l DEBUG
-t=2022-05-09 21:27:20,066 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.gamma
-t=2022-05-09 21:27:20,066 lvl=INFO msg=CSV source directory: test/testdata/
-t=2022-05-09 21:27:20,066 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
-t=2022-05-09 21:27:20,067 lvl=DEBUG msg=Creating classification for geographic variable: GEO1
-t=2022-05-09 21:27:20,067 lvl=DEBUG msg=Creating classification for geographic variable: GEO2
-t=2022-05-09 21:27:20,067 lvl=DEBUG msg=Creating classification for geographic variable: GEO_PRIV
-t=2022-05-09 21:27:20,067 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
-t=2022-05-09 21:27:20,068 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS1
-t=2022-05-09 21:27:20,068 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS2
-t=2022-05-09 21:27:20,068 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS3
-t=2022-05-09 21:27:20,068 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
-t=2022-05-09 21:27:20,068 lvl=DEBUG msg=Loaded metadata for Cantabular variable: GEO1
-t=2022-05-09 21:27:20,068 lvl=DEBUG msg=Loaded metadata for Cantabular variable: GEO2
-t=2022-05-09 21:27:20,068 lvl=INFO msg=Dropped non public classification: GEO_PRIV
-t=2022-05-09 21:27:20,068 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
-t=2022-05-09 21:27:20,068 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB1
-t=2022-05-09 21:27:20,068 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB2
-t=2022-05-09 21:27:20,068 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB3
-t=2022-05-09 21:27:20,068 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
-t=2022-05-09 21:27:20,069 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS1
-t=2022-05-09 21:27:20,069 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS2
-t=2022-05-09 21:27:20,069 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS3
-t=2022-05-09 21:27:20,069 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
-t=2022-05-09 21:27:20,069 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS4
-t=2022-05-09 21:27:20,069 lvl=INFO msg=Loaded metadata for 4 Cantabular tables
-t=2022-05-09 21:27:20,069 lvl=INFO msg=Loaded service metadata
-t=2022-05-09 21:27:20,069 lvl=INFO msg=Output files will be written in Cantabular 9.3.0 format
-t=2022-05-09 21:27:20,070 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v9-3-0_unknown-metadata-version_dataset-md_20220509-1.json
-t=2022-05-09 21:27:20,071 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v9-3-0_unknown-metadata-version_tables-md_20220509-1.json
-t=2022-05-09 21:27:20,071 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v9-3-0_unknown-metadata-version_service-md_20220509-1.json
+t=2022-05-24 16:40:46,032 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.delta
+t=2022-05-24 16:40:46,033 lvl=INFO msg=CSV source directory: test/testdata/
+t=2022-05-24 16:40:46,033 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
+t=2022-05-24 16:40:46,034 lvl=DEBUG msg=Creating classification for geographic variable: GEO1
+t=2022-05-24 16:40:46,034 lvl=DEBUG msg=Creating classification for geographic variable: GEO2
+t=2022-05-24 16:40:46,034 lvl=DEBUG msg=Creating classification for geographic variable: GEO_PRIV
+t=2022-05-24 16:40:46,034 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
+t=2022-05-24 16:40:46,035 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS1
+t=2022-05-24 16:40:46,035 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS2
+t=2022-05-24 16:40:46,035 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS3
+t=2022-05-24 16:40:46,035 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
+t=2022-05-24 16:40:46,035 lvl=DEBUG msg=Loaded metadata for Cantabular variable: GEO1
+t=2022-05-24 16:40:46,035 lvl=DEBUG msg=Loaded metadata for Cantabular variable: GEO2
+t=2022-05-24 16:40:46,035 lvl=INFO msg=Dropped non public classification: GEO_PRIV
+t=2022-05-24 16:40:46,035 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
+t=2022-05-24 16:40:46,035 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB1
+t=2022-05-24 16:40:46,035 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB2
+t=2022-05-24 16:40:46,035 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB3
+t=2022-05-24 16:40:46,035 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
+t=2022-05-24 16:40:46,036 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS1
+t=2022-05-24 16:40:46,036 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS2
+t=2022-05-24 16:40:46,036 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS3
+t=2022-05-24 16:40:46,036 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
+t=2022-05-24 16:40:46,036 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS4
+t=2022-05-24 16:40:46,036 lvl=INFO msg=Loaded metadata for 4 Cantabular tables
+t=2022-05-24 16:40:46,036 lvl=INFO msg=Loaded service metadata
+t=2022-05-24 16:40:46,036 lvl=INFO msg=Output files will be written in Cantabular 10.0.0 format
+t=2022-05-24 16:40:46,037 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-0-0_unknown-metadata-version_dataset-md_20220524-1.json
+t=2022-05-24 16:40:46,038 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-0-0_unknown-metadata-version_tables-md_20220524-1.json
+t=2022-05-24 16:40:46,038 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-0-0_unknown-metadata-version_service-md_20220524-1.json
 ```
 
 Output file names
@@ -92,9 +92,9 @@ Output file names
 
 The output file names are formatted as follows:
 ```
-<prefix>cantabm_9-3-0_<metadata master version>_dataset-md_<date as yyyymmdd-><build number>.json
-<prefix>cantabm_9-3-0_<metadata master version>_service-md_<date as yyyymmdd-><build number>.json
-<prefix>cantabm_9-3-0_<metadata master version>_tables-md_<date as yyyymmdd-><build number>.json
+<prefix>cantabm_10-0-0_<metadata master version>_dataset-md_<date as yyyymmdd-><build number>.json
+<prefix>cantabm_10-0-0_<metadata master version>_service-md_<date as yyyymmdd-><build number>.json
+<prefix>cantabm_10-0-0_<metadata master version>_tables-md_<date as yyyymmdd-><build number>.json
 ```
 
 The `prefix`, `metadata master version` and `build number` can be specified using command line
@@ -114,21 +114,21 @@ arguments as described in the help text for `ons_csv_to_ctb_json_main.py`:
 For example:
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/ -g test/testdata/geography/geography.csv -o ctb_metadata_files/ -p t -m test -b 42
-t=2022-05-09 21:27:57,633 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.gamma
-t=2022-05-09 21:27:57,633 lvl=INFO msg=CSV source directory: test/testdata/
-t=2022-05-09 21:27:57,633 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
-t=2022-05-09 21:27:57,634 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
-t=2022-05-09 21:27:57,635 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
-t=2022-05-09 21:27:57,635 lvl=INFO msg=Dropped non public classification: GEO_PRIV
-t=2022-05-09 21:27:57,635 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
-t=2022-05-09 21:27:57,635 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
-t=2022-05-09 21:27:57,636 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
-t=2022-05-09 21:27:57,636 lvl=INFO msg=Loaded metadata for 4 Cantabular tables
-t=2022-05-09 21:27:57,636 lvl=INFO msg=Loaded service metadata
-t=2022-05-09 21:27:57,636 lvl=INFO msg=Output files will be written in Cantabular 9.3.0 format
-t=2022-05-09 21:27:57,637 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/t_cantabm_v9-3-0_test_dataset-md_20220509-42.json
-t=2022-05-09 21:27:57,637 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/t_cantabm_v9-3-0_test_tables-md_20220509-42.json
-t=2022-05-09 21:27:57,638 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/t_cantabm_v9-3-0_test_service-md_20220509-42.json
+t=2022-05-24 16:41:24,500 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.delta
+t=2022-05-24 16:41:24,500 lvl=INFO msg=CSV source directory: test/testdata/
+t=2022-05-24 16:41:24,500 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
+t=2022-05-24 16:41:24,502 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
+t=2022-05-24 16:41:24,502 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
+t=2022-05-24 16:41:24,502 lvl=INFO msg=Dropped non public classification: GEO_PRIV
+t=2022-05-24 16:41:24,502 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
+t=2022-05-24 16:41:24,502 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
+t=2022-05-24 16:41:24,503 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
+t=2022-05-24 16:41:24,503 lvl=INFO msg=Loaded metadata for 4 Cantabular tables
+t=2022-05-24 16:41:24,503 lvl=INFO msg=Loaded service metadata
+t=2022-05-24 16:41:24,503 lvl=INFO msg=Output files will be written in Cantabular 10.0.0 format
+t=2022-05-24 16:41:24,504 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/t_cantabm_v10-0-0_test_dataset-md_20220524-42.json
+t=2022-05-24 16:41:24,505 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/t_cantabm_v10-0-0_test_tables-md_20220524-42.json
+t=2022-05-24 16:41:24,505 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/t_cantabm_v10-0-0_test_service-md_20220524-42.json
 ```
 
 Using data with errors
@@ -143,42 +143,47 @@ This repository contains some test data that is full of errors. It can be used t
 of the `--best-effort` flag as shown below:
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/best_effort  -o ctb_metadata_files/ -m best-effort --best-effort
-t=2022-05-13 16:07:44,712 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.gamma
-t=2022-05-13 16:07:44,712 lvl=INFO msg=CSV source directory: test/testdata/best_effort
-t=2022-05-13 16:07:44,713 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:3 no value supplied for required field Variable_Mnemonic
-t=2022-05-13 16:07:44,713 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:3 dropping record
-t=2022-05-13 16:07:44,713 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:4 duplicate value CLASS1 for Classification_Mnemonic
-t=2022-05-13 16:07:44,713 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:4 dropping record
-t=2022-05-13 16:07:44,713 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:5 invalid value x for Number_Of_Category_Items
-t=2022-05-13 16:07:44,713 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:5 ignoring field Number_Of_Category_Items
-t=2022-05-13 16:07:44,713 lvl=WARNING msg=Reading test/testdata/best_effort/Category.csv Unexpected number of categories for CLASS1: expected 4 but found 1
-t=2022-05-13 16:07:44,713 lvl=INFO msg=No geography file specified
-t=2022-05-13 16:07:44,713 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Database_Variable.csv Lowest_Geog_Variable_Flag set on GEO3 and GEO1 for database DB1
-t=2022-05-13 16:07:44,714 lvl=INFO msg=Loaded metadata for 1 Cantabular datasets
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:4 duplicate value combo DS1/VAR1 for Dataset_Mnemonic/Variable_Mnemonic
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:4 dropping record
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 Lowest_Geog_Variable_Flag set on non-geographic variable VAR1 for dataset DS1
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 Processing_Priority not specified for classification CLASS1 in dataset DS1
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 using 0 for Processing_Priority
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:3 Classification_Mnemonic must not be specified for geographic variable GEO1 in dataset DS1
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:3 Processing_Priority must not be specified for geographic variable GEO1 in dataset DS1
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:5 Lowest_Geog_Variable_Flag set on variable GEO2 and GEO1 for dataset DS1
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:7 Classification must be specified for non-geographic VAR2 in dataset DS1
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:7 dropping record
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:8 Invalid classification CLASS1 specified for variable VAR3 in dataset DS1
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:8 dropping record
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv Invalid processing_priorities [0] for dataset DS1
-t=2022-05-13 16:07:44,714 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:3 DS2 has classification CLASS3 that is not in database DB1
-t=2022-05-13 16:07:44,715 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:4 DS3 has no associated classifications or geographic variable
-t=2022-05-13 16:07:44,715 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:4 dropping record
-t=2022-05-13 16:07:44,715 lvl=INFO msg=Loaded metadata for 2 Cantabular tables
-t=2022-05-13 16:07:44,715 lvl=INFO msg=Loaded service metadata
-t=2022-05-13 16:07:44,715 lvl=WARNING msg=16 errors were encountered during processing
-t=2022-05-13 16:07:44,715 lvl=INFO msg=Output files will be written in Cantabular 9.3.0 format
-t=2022-05-13 16:07:44,715 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v9-3-0_best-effort_dataset-md_20220513-1.json
-t=2022-05-13 16:07:44,716 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v9-3-0_best-effort_tables-md_20220513-1.json
-t=2022-05-13 16:07:44,716 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v9-3-0_best-effort_service-md_20220513-1.json
+t=2022-05-24 20:29:16,314 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.delta
+t=2022-05-24 20:29:16,314 lvl=INFO msg=CSV source directory: test/testdata/best_effort
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:3 no value supplied for required field Variable_Mnemonic
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:3 dropping record
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:4 duplicate value CLASS1 for Classification_Mnemonic
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:4 dropping record
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:5 invalid value x for Number_Of_Category_Items
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:5 ignoring field Number_Of_Category_Items
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:3 different Codebook_Mnemonic values specified for classification CLASS1: CLASS1 (Codebook A) and CLASS1 (Codebook)
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:4 CLASS1 (Codebook) is Codebook_Mnemonic for both CLASS1 and CLASS3
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:4 ignoring field Codebook_Mnemonic
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:5 CLASS1 is an invalid Codebook_Mnemonic for classification CLASS4 as it is already the Classification_Mnemonic for another classification
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:5 ignoring field Codebook_Mnemonic
+t=2022-05-24 20:29:16,316 lvl=WARNING msg=Reading test/testdata/best_effort/Category.csv Unexpected number of categories for CLASS1: expected 4 but found 1
+t=2022-05-24 20:29:16,316 lvl=INFO msg=No geography file specified
+t=2022-05-24 20:29:16,316 lvl=INFO msg=Loaded metadata for 6 Cantabular variables
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Database_Variable.csv Lowest_Geog_Variable_Flag set on GEO3 and GEO1 for database DB1
+t=2022-05-24 20:29:16,317 lvl=INFO msg=Loaded metadata for 1 Cantabular datasets
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:4 duplicate value combo DS1/VAR1 for Dataset_Mnemonic/Variable_Mnemonic
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:4 dropping record
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 Lowest_Geog_Variable_Flag set on non-geographic variable VAR1 for dataset DS1
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 Processing_Priority not specified for classification CLASS1 in dataset DS1
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 using 0 for Processing_Priority
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:3 Classification_Mnemonic must not be specified for geographic variable GEO1 in dataset DS1
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:3 Processing_Priority must not be specified for geographic variable GEO1 in dataset DS1
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:5 Lowest_Geog_Variable_Flag set on variable GEO2 and GEO1 for dataset DS1
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:7 Classification must be specified for non-geographic VAR2 in dataset DS1
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:7 dropping record
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:8 Invalid classification CLASS1 specified for variable VAR3 in dataset DS1
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:8 dropping record
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv Invalid processing_priorities [0] for dataset DS1
+t=2022-05-24 20:29:16,317 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:3 DS2 has classification CLASS3 that is not in database DB1
+t=2022-05-24 20:29:16,318 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:4 DS3 has no associated classifications or geographic variable
+t=2022-05-24 20:29:16,318 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:4 dropping record
+t=2022-05-24 20:29:16,318 lvl=INFO msg=Loaded metadata for 2 Cantabular tables
+t=2022-05-24 20:29:16,318 lvl=INFO msg=Loaded service metadata
+t=2022-05-24 20:29:16,318 lvl=WARNING msg=19 errors were encountered during processing
+t=2022-05-24 20:29:16,318 lvl=INFO msg=Output files will be written in Cantabular 10.0.0 format
+t=2022-05-24 20:29:16,318 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-0-0_best-effort_dataset-md_20220524-1.json
+t=2022-05-24 20:29:16,319 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-0-0_best-effort_tables-md_20220524-1.json
+t=2022-05-24 20:29:16,319 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-0-0_best-effort_service-md_20220524-1.json
 ```
 
 Many lines contain strings such as `test/testdata/best_effort/Dataset.csv:4` this means that an error has been detected
@@ -199,53 +204,53 @@ can be found in the `sample_2011` directory.
 Use this command to convert the files to JSON (with debugging enabled):
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i sample_2011/ -g sample_2011/geography.csv -o ctb_metadata_files/ -m 2001-sample -l DEBUG
-t=2022-05-09 21:28:29,336 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.gamma
-t=2022-05-09 21:28:29,336 lvl=INFO msg=CSV source directory: sample_2011/
-t=2022-05-09 21:28:29,336 lvl=INFO msg=Geography file: sample_2011/geography.csv
-t=2022-05-09 21:28:29,354 lvl=DEBUG msg=Creating classification for geographic variable: Region
-t=2022-05-09 21:28:29,354 lvl=DEBUG msg=Creating classification for geographic variable: Country
-t=2022-05-09 21:28:29,356 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Residence Type
-t=2022-05-09 21:28:29,356 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Family Composition
-t=2022-05-09 21:28:29,356 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Population Base
-t=2022-05-09 21:28:29,356 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Sex
-t=2022-05-09 21:28:29,356 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Age
-t=2022-05-09 21:28:29,356 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Marital Status
-t=2022-05-09 21:28:29,356 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Student
-t=2022-05-09 21:28:29,356 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Country of Birth
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Health
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Ethnic Group
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Religion
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Economic Activity
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Occupation
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Industry
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Hours worked per week
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Approximated Social Grade
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Region
-t=2022-05-09 21:28:29,357 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Country
-t=2022-05-09 21:28:29,357 lvl=INFO msg=Loaded metadata for 18 Cantabular variables
-t=2022-05-09 21:28:29,358 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: Teaching-Dataset
-t=2022-05-09 21:28:29,358 lvl=INFO msg=Loaded metadata for 1 Cantabular datasets
-t=2022-05-09 21:28:29,360 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC2101EW
-t=2022-05-09 21:28:29,360 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC1117EW
-t=2022-05-09 21:28:29,360 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC2107EW
-t=2022-05-09 21:28:29,360 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC6107EW
-t=2022-05-09 21:28:29,360 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC6112EW
-t=2022-05-09 21:28:29,360 lvl=INFO msg=Loaded metadata for 5 Cantabular tables
-t=2022-05-09 21:28:29,361 lvl=INFO msg=Loaded service metadata
-t=2022-05-09 21:28:29,361 lvl=INFO msg=Output files will be written in Cantabular 9.3.0 format
-t=2022-05-09 21:28:29,364 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v9-3-0_2001-sample_dataset-md_20220509-1.json
-t=2022-05-09 21:28:29,365 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v9-3-0_2001-sample_tables-md_20220509-1.json
-t=2022-05-09 21:28:29,365 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v9-3-0_2001-sample_service-md_20220509-1.json
+t=2022-05-24 16:51:22,438 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.delta
+t=2022-05-24 16:51:22,438 lvl=INFO msg=CSV source directory: sample_2011/
+t=2022-05-24 16:51:22,438 lvl=INFO msg=Geography file: sample_2011/geography.csv
+t=2022-05-24 16:51:22,441 lvl=DEBUG msg=Creating classification for geographic variable: Region
+t=2022-05-24 16:51:22,442 lvl=DEBUG msg=Creating classification for geographic variable: Country
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Residence Type
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Family Composition
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Population Base
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Sex
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Age
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Marital Status
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Student
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Country of Birth
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Health
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Ethnic Group
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Religion
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Economic Activity
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Occupation
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Industry
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Hours worked per week
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Approximated Social Grade
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Region
+t=2022-05-24 16:51:22,443 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Country
+t=2022-05-24 16:51:22,443 lvl=INFO msg=Loaded metadata for 18 Cantabular variables
+t=2022-05-24 16:51:22,444 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: Teaching-Dataset
+t=2022-05-24 16:51:22,444 lvl=INFO msg=Loaded metadata for 1 Cantabular datasets
+t=2022-05-24 16:51:22,445 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC2101EW
+t=2022-05-24 16:51:22,445 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC1117EW
+t=2022-05-24 16:51:22,445 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC2107EW
+t=2022-05-24 16:51:22,445 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC6107EW
+t=2022-05-24 16:51:22,445 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC6112EW
+t=2022-05-24 16:51:22,445 lvl=INFO msg=Loaded metadata for 5 Cantabular tables
+t=2022-05-24 16:51:22,445 lvl=INFO msg=Loaded service metadata
+t=2022-05-24 16:51:22,445 lvl=INFO msg=Output files will be written in Cantabular 10.0.0 format
+t=2022-05-24 16:51:22,448 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-0-0_2001-sample_dataset-md_20220524-1.json
+t=2022-05-24 16:51:22,449 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-0-0_2001-sample_tables-md_20220524-1.json
+t=2022-05-24 16:51:22,449 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-0-0_2001-sample_service-md_20220524-1.json
 ```
 
 Load the JSON files with cantabular-metadata
 ============================================
 
-To load the generated JSON files into `cantabular-metadata` (version 9.3.0) run the following
+To load the generated JSON files into `cantabular-metadata` (version 10.0.0) run the following
 commands, substituting the file names and paths as appropriate:
 ```
 cd ctb_metadata_files
-CANTABULAR_METADATA_GRAPHQL_TYPES_FILE=metadata.graphql CANTABULAR_METADATA_SERVICE_FILE=cantabm_v9-3-0_unknown-metadata-version_service-md_20220428-1.json CANTABULAR_METADATA_DATASET_FILES=cantabm_v9-3-0_unknown-metadata-version_dataset-md_20220428-1.json CANTABULAR_METADATA_TABLE_FILES=cantabm_v9-3-0_unknown-metadata-version_tables-md_20220428-1.json <PATH_TO_BINARY>/cantabular-metadata
+CANTABULAR_METADATA_GRAPHQL_TYPES_FILE=metadata.graphql CANTABULAR_METADATA_SERVICE_FILE=cantabm_v10-0-0_unknown-metadata-version_service-md_20220524-1.json CANTABULAR_METADATA_DATASET_FILES=cantabm_v10-0-0_unknown-metadata-version_dataset-md_20220524-1.json CANTABULAR_METADATA_TABLE_FILES=cantabm_v10-0-0_unknown-metadata-version_tables-md_20220524-1.json <PATH_TO_BINARY>/cantabular-metadata
 ```
 
 The metadata can be queried via a GraphQL interface. By default this is accessible at:
@@ -257,7 +262,7 @@ and this can be used to construct GraphQL queries when the service is accessed v
 
 The following query can be used to obtain Welsh information for a single named variable (from the test data):
 
-http://localhost:8493/graphql?query=%7Bdataset(name%3A%22DB1%22%2Clang%3A%22cy%22)%7Bvars(names%3A%5B%22CLASS1%22%5D)%7BcatLabels%20name%20label%20all%7D%7D%7D%0A
+http://localhost:8493/graphql?query=%7Bdataset(name%3A%22DB1%22%2Clang%3A%22cy%22)%7Bvars(names%3A%5B%22CLASS1%20(Codebook)%22%5D)%7BcatLabels%20name%20label%20all%7D%7D%7D%0A
 
 This query can be used to obtain information for a single named table:
 
@@ -278,26 +283,26 @@ Other Cantabular versions
 =========================
 
 The `-v` argument can be used to generate output files that are compatible with a different version of Cantabular.
-At present only 9.2.0 and 9.3.0 are supported. If any other version is specified then the specified version
-will be reflected in the output filenames, but `9.3.0` format will be used.
+At present only 9.2.0, 9.3.0 and 10.0.0 are supported. If any other version is specified then the specified version
+will be reflected in the output filenames, but `10.0.0` format will be used.
 
 To generate version 9.2.0 compatible files from the test data use the following command:
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/ -g test/testdata/geography/geography.csv -o ctb_metadata_files/ -v 9.2.0
-t=2022-05-09 21:40:49,218 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.gamma
-t=2022-05-09 21:40:49,218 lvl=INFO msg=CSV source directory: test/testdata/
-t=2022-05-09 21:40:49,218 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
-t=2022-05-09 21:40:49,220 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
-t=2022-05-09 21:40:49,220 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
-t=2022-05-09 21:40:49,220 lvl=INFO msg=Dropped non public classification: GEO_PRIV
-t=2022-05-09 21:40:49,220 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
-t=2022-05-09 21:40:49,221 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
-t=2022-05-09 21:40:49,222 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
-t=2022-05-09 21:40:49,222 lvl=INFO msg=Loaded metadata for 4 Cantabular tables
-t=2022-05-09 21:40:49,222 lvl=INFO msg=Loaded service metadata
-t=2022-05-09 21:40:49,222 lvl=INFO msg=Output files will be written in Cantabular 9.2.0 format
-t=2022-05-09 21:40:49,223 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v9-2-0_unknown-metadata-version_dataset-md_20220509-1.json
-t=2022-05-09 21:40:49,223 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v9-2-0_unknown-metadata-version_service-md_20220509-1.json
+t=2022-05-24 16:52:04,154 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.1.delta
+t=2022-05-24 16:52:04,154 lvl=INFO msg=CSV source directory: test/testdata/
+t=2022-05-24 16:52:04,154 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
+t=2022-05-24 16:52:04,156 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
+t=2022-05-24 16:52:04,156 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
+t=2022-05-24 16:52:04,156 lvl=INFO msg=Dropped non public classification: GEO_PRIV
+t=2022-05-24 16:52:04,156 lvl=INFO msg=Loaded metadata for 5 Cantabular variables
+t=2022-05-24 16:52:04,157 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
+t=2022-05-24 16:52:04,157 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
+t=2022-05-24 16:52:04,157 lvl=INFO msg=Loaded metadata for 4 Cantabular tables
+t=2022-05-24 16:52:04,157 lvl=INFO msg=Loaded service metadata
+t=2022-05-24 16:52:04,158 lvl=INFO msg=Output files will be written in Cantabular 9.2.0 format
+t=2022-05-24 16:52:04,159 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v9-2-0_unknown-metadata-version_dataset-md_20220524-1.json
+t=2022-05-24 16:52:04,159 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v9-2-0_unknown-metadata-version_service-md_20220524-1.json
 ```
 
 No tables metadata file is produced. The tables data is embedded in the service metadata file.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+1.1.delta
+---------
+- Cantabular version 10.0.0 is now the default version. The file format for version 10.0.0 and
+  9.3.0 are identical.
+- Use the Codebook_Mnemonic from Category_Mapping.csv as the variable name.
+- Drop the Parent_Classification_Mnemonic from VariableMetadata in the GraphQL schema. This
+  information can be obtained from the codebook and its contents are ambiguous since a variable
+  name can now be either the Classification_Mnemonic or Codebook_Mnemonic.
+
 1.1.gamma
 ---------
 - In `--best-effort` mode don't drop tables (ONS datasets) which use variables (ONS classifications) that

--- a/bin/ons_csv_to_ctb_json_load.py
+++ b/bin/ons_csv_to_ctb_json_load.py
@@ -748,6 +748,10 @@ class Loader:
             codebook_mnemonic = classification_to_codebook.get(classification_mnemonic,
                                                                classification_mnemonic)
 
+            # Discard the Parent_Classification_Mnemonic. It can be obtained via the codebook and
+            # the value may be ambiguous since some classifications are renamed using the
+            # Codebook_Mnemonic from Category_Mapping.csv.
+            del classification['Parent_Classification_Mnemonic']
             del classification['Signed_Off_Flag']
             del classification['Flat_Classification_Flag']
             del classification['Id']
@@ -782,7 +786,6 @@ class Loader:
                 classifications[variable_mnemonic] = BilingualDict(
                     {
                         'Mnemonic_2011': None,
-                        'Parent_Classification_Mnemonic': variable_mnemonic,
                         'Default_Classification_Flag': None,
                         'Version': variable.private['Version'],
                         'ONS_Variable': variable,

--- a/bin/ons_csv_to_ctb_json_main.py
+++ b/bin/ons_csv_to_ctb_json_main.py
@@ -9,15 +9,16 @@ from datetime import date
 from ons_csv_to_ctb_json_load import Loader, PUBLIC_SECURITY_MNEMONIC
 from ons_csv_to_ctb_json_bilingual import BilingualDict, Bilingual
 
-VERSION = '1.1.gamma'
+VERSION = '1.1.delta'
 
 SYSTEM = 'cantabm'
-DEFAULT_CANTABULAR_VERSION = '9.3.0'
+DEFAULT_CANTABULAR_VERSION = '10.0.0'
+CANTABULAR_V9_3_0 = '9.3.0'
 CANTABULAR_V9_2_0 = '9.2.0'
 FILE_CONTENT_TYPE_DATASET = 'dataset-md'
 FILE_CONTENT_TYPE_TABLES = 'tables-md'
 FILE_CONTENT_TYPE_SERVICE = 'service-md'
-KNOWN_CANTABULAR_VERSIONS = [DEFAULT_CANTABULAR_VERSION, CANTABULAR_V9_2_0]
+KNOWN_CANTABULAR_VERSIONS = [DEFAULT_CANTABULAR_VERSION, CANTABULAR_V9_3_0, CANTABULAR_V9_2_0]
 
 
 def filename_segment(value):

--- a/bin/ons_csv_to_ctb_json_main.py
+++ b/bin/ons_csv_to_ctb_json_main.py
@@ -241,7 +241,7 @@ def build_ctb_variables(classifications, cat_labels):
             continue
 
         ctb_class = {
-            'name': mnemonic,
+            'name': classification.private['Codebook_Mnemonic'],
             'label': classification.private['Classification_Label'],
             'description': classification.private['Variable_Description'],
             'meta': classification,
@@ -331,7 +331,7 @@ def build_ctb_tables(datasets):
         table = {
             'name': mnemonic,
             'datasetName': dataset.private['Database_Mnemonic'],
-            'vars': dataset.private['Classifications'],
+            'vars': dataset.private['Codebook_Mnemonics'],
             'ref': [ref.english(), ref.welsh()],
         }
 

--- a/ctb_metadata_files/metadata.graphql
+++ b/ctb_metadata_files/metadata.graphql
@@ -11,7 +11,6 @@ type DatasetMetadata {
 
 type VariableMetadata {
   Mnemonic_2011: String
-  Parent_Classification_Mnemonic: String
   Default_Classification_Flag: String
   Version: String!
   ONS_Variable: ONS_Variable!

--- a/ctb_metadata_files/metadata_9_2_0.graphql
+++ b/ctb_metadata_files/metadata_9_2_0.graphql
@@ -24,7 +24,6 @@ type VariableMetadata {
   description: String!
   Mnemonic_2011: String
   Flat_Classification_Flag: String
-  Parent_Classification_Mnemonic: String
   Default_Classification_Flag: String
   Version: String!
   ONS_Variable: ONS_Variable!

--- a/sample_2011/Category_Mapping.csv
+++ b/sample_2011/Category_Mapping.csv
@@ -1,0 +1,1 @@
+Classification_Mnemonic,Codebook_Mnemonic

--- a/test/expected/dataset-metadata-best-effort.json
+++ b/test/expected/dataset-metadata-best-effort.json
@@ -19,7 +19,6 @@
                 "description": "VAR1 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -53,7 +52,6 @@
                 "description": "VAR3 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -120,7 +118,6 @@
                 "description": "GEO1 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO1",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -154,7 +151,6 @@
                 "description": "GEO2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO2",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -188,7 +184,6 @@
                 "description": "GEO3 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO3",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -238,7 +233,6 @@
                 "description": "VAR1 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -272,7 +266,6 @@
                 "description": "VAR3 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -339,7 +332,6 @@
                 "description": "GEO1 Description (Welsh)",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO1",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -373,7 +365,6 @@
                 "description": "GEO2 Description (Welsh)",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO2",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -407,7 +398,6 @@
                 "description": "GEO3 Description (Welsh)",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO3",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {

--- a/test/expected/dataset-metadata-best-effort.json
+++ b/test/expected/dataset-metadata-best-effort.json
@@ -14,7 +14,7 @@
         },
         "vars": [
             {
-                "name": "CLASS1",
+                "name": "CLASS1 (Codebook)",
                 "label": "CLASS1 Label Internal",
                 "description": "VAR1 Description",
                 "meta": {
@@ -65,6 +65,39 @@
                         "Variable_Title": "VAR3 Title",
                         "Comparability_Comments": "VAR3 Comparability Comments",
                         "Uk_Comparison_Comments": "VAR3 UK Comparison Comments",
+                        "Geographic_Abbreviation": null,
+                        "Geographic_Theme": null,
+                        "Geographic_Coverage": null,
+                        "Variable_Type": {
+                            "Variable_Type_Code": "DVO",
+                            "Variable_Type_Description": "Derived variable"
+                        },
+                        "Statistical_Unit": null,
+                        "Topic": null,
+                        "Keywords": [],
+                        "Questions": []
+                    },
+                    "Topics": []
+                },
+                "catLabels": null
+            },
+            {
+                "name": "CLASS4",
+                "label": "CLASS4 Label Internal",
+                "description": "VAR1 Description",
+                "meta": {
+                    "Mnemonic_2011": null,
+                    "Default_Classification_Flag": null,
+                    "Version": "1",
+                    "ONS_Variable": {
+                        "Variable_Mnemonic": "VAR1",
+                        "Variable_Mnemonic_2011": null,
+                        "Version": "1",
+                        "Quality_Statement_Text": null,
+                        "Quality_Summary_URL": null,
+                        "Variable_Title": "VAR1 Title",
+                        "Comparability_Comments": "VAR1 Comparability Comments",
+                        "Uk_Comparison_Comments": "VAR1 UK Comparison Comments",
                         "Geographic_Abbreviation": null,
                         "Geographic_Theme": null,
                         "Geographic_Coverage": null,
@@ -200,7 +233,7 @@
         },
         "vars": [
             {
-                "name": "CLASS1",
+                "name": "CLASS1 (Codebook)",
                 "label": "CLASS1 Label Internal",
                 "description": "VAR1 Description",
                 "meta": {
@@ -251,6 +284,39 @@
                         "Variable_Title": "VAR3 Title",
                         "Comparability_Comments": "VAR3 Comparability Comments",
                         "Uk_Comparison_Comments": "VAR3 UK Comparison Comments",
+                        "Geographic_Abbreviation": null,
+                        "Geographic_Theme": null,
+                        "Geographic_Coverage": null,
+                        "Variable_Type": {
+                            "Variable_Type_Code": "DVO",
+                            "Variable_Type_Description": "Derived variable"
+                        },
+                        "Statistical_Unit": null,
+                        "Topic": null,
+                        "Keywords": [],
+                        "Questions": []
+                    },
+                    "Topics": []
+                },
+                "catLabels": null
+            },
+            {
+                "name": "CLASS4",
+                "label": "CLASS4 Label Internal",
+                "description": "VAR1 Description",
+                "meta": {
+                    "Mnemonic_2011": null,
+                    "Default_Classification_Flag": null,
+                    "Version": "1",
+                    "ONS_Variable": {
+                        "Variable_Mnemonic": "VAR1",
+                        "Variable_Mnemonic_2011": null,
+                        "Version": "1",
+                        "Quality_Statement_Text": null,
+                        "Quality_Summary_URL": null,
+                        "Variable_Title": "VAR1 Title",
+                        "Comparability_Comments": "VAR1 Comparability Comments",
+                        "Uk_Comparison_Comments": "VAR1 UK Comparison Comments",
                         "Geographic_Abbreviation": null,
                         "Geographic_Theme": null,
                         "Geographic_Coverage": null,

--- a/test/expected/dataset-metadata-no-geo.json
+++ b/test/expected/dataset-metadata-no-geo.json
@@ -19,7 +19,6 @@
                 "description": "VAR1 Description",
                 "meta": {
                     "Mnemonic_2011": "CLASS1 2011",
-                    "Parent_Classification_Mnemonic": "CLASS1 Parent",
                     "Default_Classification_Flag": "Y",
                     "Version": "1",
                     "ONS_Variable": {
@@ -89,7 +88,6 @@
                 "description": "VAR2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -123,7 +121,6 @@
                 "description": "VAR3 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": "N",
                     "Version": "1",
                     "ONS_Variable": {
@@ -157,7 +154,6 @@
                 "description": "GEO1 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO1",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -208,7 +204,6 @@
                 "description": "GEO2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO2",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -258,7 +253,6 @@
                 "description": "VAR1 Description (Welsh)",
                 "meta": {
                     "Mnemonic_2011": "CLASS1 2011",
-                    "Parent_Classification_Mnemonic": "CLASS1 Parent",
                     "Default_Classification_Flag": "Y",
                     "Version": "1",
                     "ONS_Variable": {
@@ -333,7 +327,6 @@
                 "description": "VAR2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -369,7 +362,6 @@
                 "description": "VAR3 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": "N",
                     "Version": "1",
                     "ONS_Variable": {
@@ -403,7 +395,6 @@
                 "description": "GEO1 Description (Welsh)",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO1",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -454,7 +445,6 @@
                 "description": "GEO2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO2",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {

--- a/test/expected/dataset-metadata-no-geo.json
+++ b/test/expected/dataset-metadata-no-geo.json
@@ -14,7 +14,7 @@
         },
         "vars": [
             {
-                "name": "CLASS1",
+                "name": "CLASS1 (Codebook)",
                 "label": "CLASS1 Label",
                 "description": "VAR1 Description",
                 "meta": {
@@ -253,7 +253,7 @@
         },
         "vars": [
             {
-                "name": "CLASS1",
+                "name": "CLASS1 (Codebook)",
                 "label": "CLASS1 Label Welsh",
                 "description": "VAR1 Description (Welsh)",
                 "meta": {

--- a/test/expected/dataset-metadata.json
+++ b/test/expected/dataset-metadata.json
@@ -19,7 +19,6 @@
                 "description": "VAR1 Description",
                 "meta": {
                     "Mnemonic_2011": "CLASS1 2011",
-                    "Parent_Classification_Mnemonic": "CLASS1 Parent",
                     "Default_Classification_Flag": "Y",
                     "Version": "1",
                     "ONS_Variable": {
@@ -89,7 +88,6 @@
                 "description": "VAR2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -123,7 +121,6 @@
                 "description": "VAR3 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": "N",
                     "Version": "1",
                     "ONS_Variable": {
@@ -157,7 +154,6 @@
                 "description": "GEO1 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO1",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -208,7 +204,6 @@
                 "description": "GEO2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO2",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -258,7 +253,6 @@
                 "description": "VAR1 Description (Welsh)",
                 "meta": {
                     "Mnemonic_2011": "CLASS1 2011",
-                    "Parent_Classification_Mnemonic": "CLASS1 Parent",
                     "Default_Classification_Flag": "Y",
                     "Version": "1",
                     "ONS_Variable": {
@@ -333,7 +327,6 @@
                 "description": "VAR2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -369,7 +362,6 @@
                 "description": "VAR3 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": null,
                     "Default_Classification_Flag": "N",
                     "Version": "1",
                     "ONS_Variable": {
@@ -403,7 +395,6 @@
                 "description": "GEO1 Description (Welsh)",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO1",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {
@@ -454,7 +445,6 @@
                 "description": "GEO2 Description",
                 "meta": {
                     "Mnemonic_2011": null,
-                    "Parent_Classification_Mnemonic": "GEO2",
                     "Default_Classification_Flag": null,
                     "Version": "1",
                     "ONS_Variable": {

--- a/test/expected/dataset-metadata.json
+++ b/test/expected/dataset-metadata.json
@@ -14,7 +14,7 @@
         },
         "vars": [
             {
-                "name": "CLASS1",
+                "name": "CLASS1 (Codebook)",
                 "label": "CLASS1 Label",
                 "description": "VAR1 Description",
                 "meta": {
@@ -253,7 +253,7 @@
         },
         "vars": [
             {
-                "name": "CLASS1",
+                "name": "CLASS1 (Codebook)",
                 "label": "CLASS1 Label Welsh",
                 "description": "VAR1 Description (Welsh)",
                 "meta": {

--- a/test/expected/table-metadata-best-effort.json
+++ b/test/expected/table-metadata-best-effort.json
@@ -4,7 +4,7 @@
         "datasetName": "DB1",
         "vars": [
             "GEO1",
-            "CLASS1"
+            "CLASS1 (Codebook)"
         ],
         "ref": [
             {

--- a/test/expected/table-metadata.json
+++ b/test/expected/table-metadata.json
@@ -4,7 +4,7 @@
         "datasetName": "DB1",
         "vars": [
             "GEO1",
-            "CLASS1",
+            "CLASS1 (Codebook)",
             "CLASS2",
             "CLASS3"
         ],

--- a/test/test_best_effort.py
+++ b/test/test_best_effort.py
@@ -8,9 +8,9 @@ from io import StringIO
 from datetime import date
 import ons_csv_to_ctb_json_main
 
-FILENAME_TABLES = 'cantabm_v9-3-0_best-effort_tables-md_19700101-1.json'
-FILENAME_DATASET = 'cantabm_v9-3-0_best-effort_dataset-md_19700101-1.json'
-FILENAME_SERVICE = 'cantabm_v9-3-0_best-effort_service-md_19700101-1.json'
+FILENAME_TABLES = 'cantabm_v10-0-0_best-effort_tables-md_19700101-1.json'
+FILENAME_DATASET = 'cantabm_v10-0-0_best-effort_dataset-md_19700101-1.json'
+FILENAME_SERVICE = 'cantabm_v10-0-0_best-effort_service-md_19700101-1.json'
 
 class TestBestEffort(unittest.TestCase):
     @unittest.mock.patch('ons_csv_to_ctb_json_main.date')
@@ -45,12 +45,18 @@ class TestBestEffort(unittest.TestCase):
                 self.assertEqual(table_metadata, expected_table_metadata)
 
         warnings = [
+
             r'Classification.csv:3 no value supplied for required field Variable_Mnemonic',
             r'Classification.csv:3 dropping record',
             r'Classification.csv:4 duplicate value CLASS1 for Classification_Mnemonic',
             r'Classification.csv:4 dropping record',
             r'Classification.csv:5 invalid value x for Number_Of_Category_Items',
             r'Classification.csv:5 ignoring field Number_Of_Category_Items',
+            r'Category_Mapping.csv:3 different Codebook_Mnemonic values specified for classification CLASS1: CLASS1 \(Codebook A\) and CLASS1 \(Codebook\)',
+            r'Category_Mapping.csv:4 CLASS1 \(Codebook\) is Codebook_Mnemonic for both CLASS1 and CLASS3',
+            r'Category_Mapping.csv:4 ignoring field Codebook_Mnemonic',
+            r'Category_Mapping.csv:5 CLASS1 is an invalid Codebook_Mnemonic for classification CLASS4 as it is already the Classification_Mnemonic for another classification',
+            r'Category_Mapping.csv:5 ignoring field Codebook_Mnemonic',
             r'Category.csv Unexpected number of categories for CLASS1: expected 4 but found 1',
             r'Database_Variable.csv Lowest_Geog_Variable_Flag set on GEO3 and GEO1 for database DB1',
             r'Dataset_Variable.csv:4 duplicate value combo DS1/VAR1 for Dataset_Mnemonic/Variable_Mnemonic',
@@ -69,7 +75,7 @@ class TestBestEffort(unittest.TestCase):
             r'Dataset.csv:3 DS2 has classification CLASS3 that is not in database DB1',
             r'Dataset.csv:4 DS3 has no associated classifications or geographic variable',
             r'Dataset.csv:4 dropping record',
-            r'16 errors were encountered during processing',
+            r'19 errors were encountered during processing',
         ]
 
         self.assertEqual(len(warnings), len(cm.output))

--- a/test/test_category_mapping.py
+++ b/test/test_category_mapping.py
@@ -1,0 +1,57 @@
+import unittest.mock
+import unittest
+import os
+import pathlib
+from ons_csv_to_ctb_json_load import Loader
+from helper_funcs import conditional_mock_open, build_test_file
+
+HEADERS = ['Classification_Mnemonic', 'Codebook_Mnemonic']
+
+REQUIRED_FIELDS = {'Classification_Mnemonic': 'CLASS1',
+                   'Codebook_Mnemonic': 'CLASS1 (Codebook)'}
+
+INPUT_DIR = os.path.join(pathlib.Path(__file__).parent.resolve(), 'testdata')
+
+FILENAME = os.path.join(INPUT_DIR, 'Category_Mapping.csv')
+
+class TestCategoryMapping(unittest.TestCase):
+    def run_test(self, rows, expected_error):
+        with unittest.mock.patch('builtins.open', conditional_mock_open('Category_Mapping.csv',
+                read_data = build_test_file(HEADERS,rows))):
+            with self.assertRaisesRegex(ValueError, expected_error):
+                Loader(INPUT_DIR, None).datasets
+
+    def test_required_fields(self):
+        for field in REQUIRED_FIELDS:
+            with self.subTest(field=field):
+                row = REQUIRED_FIELDS.copy()
+                row[field] = ''
+                self.run_test([row], f'^Reading {FILENAME}:2 no value supplied for required field {field}$')
+
+    def test_invalid_values(self):
+        for field in ['Classification_Mnemonic']:
+            with self.subTest(field=field):
+                row = REQUIRED_FIELDS.copy()
+                row[field] = 'X'
+                self.run_test([row], f'^Reading {FILENAME}:2 invalid value X for {field}$')
+
+    def test_invalid_codebook_mnemonic(self):
+        self.run_test(
+            [{'Classification_Mnemonic': 'CLASS1', 'Codebook_Mnemonic': 'CLASS2'}],
+            f'^Reading {FILENAME}:2 CLASS2 is an invalid Codebook_Mnemonic for classification CLASS1 as it is already the Classification_Mnemonic for another classification$')
+
+    def test_different_codebook_mnemonics(self):
+        self.run_test(
+            [{'Classification_Mnemonic': 'CLASS1', 'Codebook_Mnemonic': 'CLASS1 (Codebook)'},
+             {'Classification_Mnemonic': 'CLASS1', 'Codebook_Mnemonic': 'CLASS1 (Codebook 2)'}],
+            f'^Reading {FILENAME}:3 different Codebook_Mnemonic values specified for classification CLASS1: CLASS1 \(Codebook 2\) and CLASS1 \(Codebook\)$')
+
+    def test_different_codebook_mnemonics(self):
+        self.run_test(
+            [{'Classification_Mnemonic': 'CLASS1', 'Codebook_Mnemonic': 'CLASS1 (Codebook)'},
+             {'Classification_Mnemonic': 'CLASS2', 'Codebook_Mnemonic': 'CLASS1 (Codebook)'}],
+            f'^Reading {FILENAME}:3 CLASS1 \(Codebook\) is Codebook_Mnemonic for both CLASS1 and CLASS2$')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -6,13 +6,13 @@ import os
 from datetime import date
 import ons_csv_to_ctb_json_main
 
-FILENAME_TABLES = 'cantabm_v9-3-0_unknown-metadata-version_tables-md_19700101-1.json'
-FILENAME_DATASET = 'cantabm_v9-3-0_unknown-metadata-version_dataset-md_19700101-1.json'
-FILENAME_SERVICE = 'cantabm_v9-3-0_unknown-metadata-version_service-md_19700101-1.json'
+FILENAME_TABLES = 'cantabm_v10-0-0_unknown-metadata-version_tables-md_19700101-1.json'
+FILENAME_DATASET = 'cantabm_v10-0-0_unknown-metadata-version_dataset-md_19700101-1.json'
+FILENAME_SERVICE = 'cantabm_v10-0-0_unknown-metadata-version_service-md_19700101-1.json'
 
-FILENAME_TABLES_NO_GEO = 't_cantabm_v9-3-0_no-geo_tables-md_19700101-2.json'
-FILENAME_DATASET_NO_GEO = 't_cantabm_v9-3-0_no-geo_dataset-md_19700101-2.json'
-FILENAME_SERVICE_NO_GEO = 't_cantabm_v9-3-0_no-geo_service-md_19700101-2.json'
+FILENAME_TABLES_NO_GEO = 't_cantabm_v10-0-0_no-geo_tables-md_19700101-2.json'
+FILENAME_DATASET_NO_GEO = 't_cantabm_v10-0-0_no-geo_dataset-md_19700101-2.json'
+FILENAME_SERVICE_NO_GEO = 't_cantabm_v10-0-0_no-geo_service-md_19700101-2.json'
 
 class TestIntegration(unittest.TestCase):
     def test_directory_validity(self):

--- a/test/testdata/Category_Mapping.csv
+++ b/test/testdata/Category_Mapping.csv
@@ -1,0 +1,2 @@
+Classification_Mnemonic,Codebook_Mnemonic
+CLASS1,CLASS1 (Codebook)

--- a/test/testdata/Classification.csv
+++ b/test/testdata/Classification.csv
@@ -1,5 +1,5 @@
 Classification_Mnemonic,Variable_Mnemonic,Id,External_Classification_Label_English,External_Classification_Label_Welsh,Number_Of_Category_Items,Mnemonic_2011,Flat_Classification_Flag,Parent_Classification_Mnemonic,Security_Mnemonic,Signed_Off_Flag,Default_Classification_Flag,Version,Internal_Classification_Label_English
-CLASS1,VAR1,1,CLASS1 Label,CLASS1 Label Welsh,6,CLASS1 2011,N,CLASS1 Parent,PUB,Y,Y,1,CLASS1 Label Internal
-CLASS2,VAR2,2,,,,,,,PUB,N,,1,CLASS2 Label Internal
+CLASS1,VAR1,1,CLASS1 Label,CLASS1 Label Welsh,6,CLASS1 2011,N,CLASS1,PUB,Y,Y,1,CLASS1 Label Internal
+CLASS2,VAR2,2,,,,,,CLASS1,PUB,N,,1,CLASS2 Label Internal
 CLASS3,VAR3,3,,CLASS3 Label Welsh,,,,,PUB,N,N,1,CLASS3 Label Internal
 CLASS_PRIV,VAR_PRIV,5,CLASS_PRIV Label,CLASS_PRIV Label Welsh,0,CLASS_PRIV 2011,Y,CLASS_PRIV,CLASS,Y,Y,1,CLASS_PRIV Label Internal

--- a/test/testdata/best_effort/Category_Mapping.csv
+++ b/test/testdata/best_effort/Category_Mapping.csv
@@ -1,0 +1,5 @@
+Classification_Mnemonic,Codebook_Mnemonic
+CLASS1,CLASS1 (Codebook)
+CLASS1,CLASS1 (Codebook A)
+CLASS3,CLASS1 (Codebook)
+CLASS4,CLASS1

--- a/test/testdata/best_effort/Classification.csv
+++ b/test/testdata/best_effort/Classification.csv
@@ -3,3 +3,4 @@ CLASS1,VAR1,1,,,4,,,,PUB,N,,1,CLASS1 Label Internal
 CLASS2,,2,,,,,,,PUB,N,,1,CLASS2 Label Internal
 CLASS1,VAR1,3,,,,,,,PUB,N,,1,CLASS1 Label Internal (Alternative)
 CLASS3,VAR3,4,,,x,,,,PUB,N,,1,CLASS3 Label Internal
+CLASS4,VAR1,5,,,,,,,PUB,N,,1,CLASS4 Label Internal


### PR DESCRIPTION
- Update to version `1.1.delta`
- Cantabular version 10.0.0 is now the default version. The file format for version 10.0.0 and 9.3.0 are identical.                                                                              
- Use the `Codebook_Mnemonic` from `Category_Mapping.csv` as the variable name.                         
- Drop the `Parent_Classification_Mnemonic` from `VariableMetadata` in the GraphQL schema. This information can be obtained from the codebook and its contents are ambiguous since a variable name can now be either the `Classification_Mnemonic` or `Codebook_Mnemonic`.                          