### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6.8, 3.7, 3.8, 3.9]

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.6.8, 3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Also updated action to use Ubuntu 20.04. The default version is now Ubuntu 22.04, but that does not support Python 3.6. We need to ensure that the scripts run on Python 3.6 as this may be the only available version on some systems.