### PR TITLE
Include English category labels

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,7 +32,7 @@ jobs:
         pydocstyle bin/*.py
     - name: Run pylint
       run: |
-        pylint --max-locals=20 --max-public-methods=30 --max-branches=50 --max-statements=90 --min-similarity-lines=7 --max-module-lines=1250 --max-locals=24 --max-attributes=10 --max-args=6 --disable=W1202 bin/*.py
+        pylint --max-locals=20 --max-public-methods=30 --max-branches=50 --max-statements=90 --min-similarity-lines=7 --max-module-lines=1300 --max-locals=24 --max-attributes=10 --max-args=6 --disable=W1202 bin/*.py
     - name: Run tests
       run: |
         PYTHONPATH=test:bin python3 -m unittest -v

--- a/CENSUS_METADATA.md
+++ b/CENSUS_METADATA.md
@@ -231,17 +231,13 @@ Cantabular metadata.
 | `label` | `String` | `Classification.External_Classification_Label_English` or `Variable.Variable_Title` for geographic variables | `Classification.External_Classification_Label_Welsh` or `Variable.Variable_Title_Welsh` for geographic variables |
 | `description` | `String` | `Variable.Variable_Description` | `Variable.Variable_Description_Welsh`. |
 | `meta` | `VariableMetadata!` | User specific metadata from `Classification.csv` | |
-| `catLabels` | `LabelsMap` | `{}` | Map of `Category.Code` to `Category.External_Category_Label_Welsh` values (see note below) |
+| `catLabels` | `LabelsMap` | Map of  `Category.Code` to `Category.External_Category_Label_English` or (`Category.Internal_Category_Label_English` if external value not populated) values| Map of `Category.Code` to `Category.External_Category_Label_Welsh` values |
 | `digest` | `String!` | Automatically populated hash of values in metadata for the variable | |
 
 It is essential that the variable `name` matches the name of the variable in the Cantabular codebook. For
 non-geographic variables this will be `Category_Mapping.Codebook_Mnemonic` if the field is populated for
 the classification or else `Classification.Classification_Mnemonic`. For base classifications the `Codebook_Mnemonic` and `Classification_Mnemonic` are likely to be different, whereas for higher level
 classifications they will be the same. The `name` will be `Variable.Variable_Mnemonic` for geographic variables.
-
-The English version of `catLabels` is an empty map. The English labels can be sourced from the codebook. The Welsh
-version of `catLabels` is a map of category codes to Welsh labels. It only contains values for Welsh labels that are
-populated i.e. it is not necessarily an exhaustive list of variable categories.
 
 ## VariableMetadata
 
@@ -605,14 +601,28 @@ with metadata for the **Region** and **Sex** variables.
       "name": "Teaching-Dataset",
       "vars": [
         {
-          "catLabels": null,
+          "catLabels": {
+            "E12000001": "North East",
+            "E12000002": "North West",
+            "E12000003": "Yorkshire and the Humber",
+            "E12000004": "East Midlands",
+            "E12000005": "West Midlands",
+            "E12000006": "East of England",
+            "E12000007": "London",
+            "E12000008": "South East",
+            "E12000009": "South West",
+            "W92000004": "Wales"
+          },
           "description": "The geographic region in which a person lives, derived from the address of their household or communal establishment.",
           "meta": {
             "Topics": []
           }
         },
         {
-          "catLabels": null,
+          "catLabels": {
+            "1": "Male",
+            "2": "Female"
+          },
           "description": "The classification of a person as either male or female.",
           "meta": {
             "Topics": [

--- a/bin/ons_csv_to_ctb_json_bilingual.py
+++ b/bin/ons_csv_to_ctb_json_bilingual.py
@@ -4,13 +4,15 @@
 class Bilingual:
     """Bilingual has an English value and a Welsh value."""
 
-    def __init__(self, english, welsh):
+    def __init__(self, english, welsh, default_to_english=True):
         """Initialize Bilingual object."""
         self._english = english
         if welsh:
             self._welsh = welsh
-        else:
+        elif default_to_english:
             self._welsh = english
+        else:
+            self._welsh = None
 
     def english(self):
         """Return English version of value."""

--- a/bin/ons_csv_to_ctb_json_load.py
+++ b/bin/ons_csv_to_ctb_json_load.py
@@ -473,6 +473,12 @@ class Loader:
 
             append_to_list_in_dict(classification_to_cats, classification_mnemonic, cat)
 
+        # Choose which English label to use for a given category
+        def english_label(cat):
+            if cat['External_Category_Label_English']:
+                return cat['External_Category_Label_English']
+            return cat['Internal_Category_Label_English']
+
         categories = {}
         for classification_mnemonic, one_var_categories in classification_to_cats.items():
             num_cat_items = \
@@ -485,9 +491,14 @@ class Loader:
 
             welsh_cats = {cat['Category_Code']: cat['External_Category_Label_Welsh']
                           for cat in one_var_categories if cat['External_Category_Label_Welsh']}
+            english_cats = {cat['Category_Code']: english_label(cat) for cat in one_var_categories}
 
-            if welsh_cats:
-                categories[classification_mnemonic] = Bilingual(None, welsh_cats)
+            # If Welsh labels are not provided then do not substitute English labels in their
+            # place. The Welsh base dataset includes the base English dataset and the metadata
+            # server will perform the substitution automatically.
+            categories[classification_mnemonic] = Bilingual(english_cats,
+                                                            welsh_cats if welsh_cats else None,
+                                                            default_to_english=False)
 
         # Categories for geographic variables are supplied in a separate file.
         if not self.geography_file:
@@ -505,9 +516,15 @@ class Loader:
                                        f'non geographic classification: {class_name}')
                 continue
 
+            english_names = {cd: nm.name for cd, nm in geo_cats.items() if nm.name}
             welsh_names = {cd: nm.welsh_name for cd, nm in geo_cats.items() if nm.welsh_name}
-            if geo_cats:
-                categories[class_name] = Bilingual(None, welsh_names if welsh_names else None)
+
+            # If Welsh names are not provided then do not substitute English names in their place.
+            # The Welsh base dataset includes the base English dataset and the metadata server
+            # will perform the substitution automatically.
+            categories[class_name] = Bilingual(english_names,
+                                               welsh_names if welsh_names else None,
+                                               default_to_english=False)
 
         return categories
 

--- a/bin/ons_csv_to_ctb_json_main.py
+++ b/bin/ons_csv_to_ctb_json_main.py
@@ -307,7 +307,13 @@ def build_ctb_datasets(databases, ctb_variables, base_dataset_name):
         },
         'vars': ctb_variables,
     })
-    ctb_datasets.extend([ctb_dataset.english(), ctb_dataset.welsh()])
+
+    # Include the English dataset in the Welsh dataset. This ensures that the Welsh output from the
+    # metadata server will include English category labels that do not have Welsh values.
+    welsh_dataset = ctb_dataset.welsh()
+    welsh_dataset['incl'] = [{'name': base_dataset_name, 'lang': 'en'}]
+
+    ctb_datasets.extend([ctb_dataset.english(), welsh_dataset])
 
     uc_base_dataset_name = base_dataset_name.upper()
     for database_mnemonic, database in databases.items():

--- a/test/expected/dataset-metadata-best-effort.json
+++ b/test/expected/dataset-metadata-best-effort.json
@@ -47,7 +47,9 @@
                     },
                     "Topics": []
                 },
-                "catLabels": null
+                "catLabels": {
+                    "CODE1": "LABEL1"
+                }
             },
             {
                 "name": "CLASS3",
@@ -548,6 +550,12 @@
                     "Topics": []
                 },
                 "catLabels": null
+            }
+        ],
+        "incl": [
+            {
+                "name": "base",
+                "lang": "en"
             }
         ]
     },

--- a/test/expected/dataset-metadata-dataset-filter.json
+++ b/test/expected/dataset-metadata-dataset-filter.json
@@ -47,7 +47,9 @@
                     },
                     "Topics": []
                 },
-                "catLabels": null
+                "catLabels": {
+                    "CODE1": "LABEL1"
+                }
             }
         ]
     },
@@ -100,6 +102,12 @@
                     "Topics": []
                 },
                 "catLabels": null
+            }
+        ],
+        "incl": [
+            {
+                "name": "base",
+                "lang": "en"
             }
         ]
     },

--- a/test/expected/dataset-metadata-no-geo.json
+++ b/test/expected/dataset-metadata-no-geo.json
@@ -80,7 +80,14 @@
                         }
                     ]
                 },
-                "catLabels": null
+                "catLabels": {
+                    "CODE3": "LABEL3",
+                    "CODE5": "LABEL5 Internal",
+                    "CODE6": "LABEL6 Internal",
+                    "CODE2": "LABEL2 Internal",
+                    "CODE4": "LABEL4 Internal",
+                    "CODE1": "LABEL1"
+                }
             },
             {
                 "name": "CLASS2",
@@ -112,7 +119,9 @@
                     },
                     "Topics": []
                 },
-                "catLabels": null
+                "catLabels": {
+                    "CODE2-1": "LABEL2-1 Internal"
+                }
             },
             {
                 "name": "CLASS3",
@@ -695,6 +704,12 @@
                     "Topics": []
                 },
                 "catLabels": null
+            }
+        ],
+        "incl": [
+            {
+                "name": "dummy",
+                "lang": "en"
             }
         ]
     },

--- a/test/expected/dataset-metadata.json
+++ b/test/expected/dataset-metadata.json
@@ -80,7 +80,14 @@
                         }
                     ]
                 },
-                "catLabels": null
+                "catLabels": {
+                    "CODE3": "LABEL3",
+                    "CODE5": "LABEL5 Internal",
+                    "CODE6": "LABEL6 Internal",
+                    "CODE2": "LABEL2 Internal",
+                    "CODE4": "LABEL4 Internal",
+                    "CODE1": "LABEL1"
+                }
             },
             {
                 "name": "CLASS2",
@@ -112,7 +119,9 @@
                     },
                     "Topics": []
                 },
-                "catLabels": null
+                "catLabels": {
+                    "CODE2-1": "LABEL2-1 Internal"
+                }
             },
             {
                 "name": "CLASS3",
@@ -309,7 +318,10 @@
                     },
                     "Topics": []
                 },
-                "catLabels": null
+                "catLabels": {
+                    "G1 CD1": "G1 NM1",
+                    "G1 CD2": "G1 NM2"
+                }
             },
             {
                 "name": "GEO2",
@@ -341,7 +353,12 @@
                     },
                     "Topics": []
                 },
-                "catLabels": null
+                "catLabels": {
+                    "CD1": "NM1",
+                    "CD2": "NM2",
+                    "CD3": "NM3",
+                    "CD4": "NM4"
+                }
             }
         ]
     },
@@ -699,6 +716,12 @@
                     "CD2": "NM2 (Welsh)",
                     "CD4": "NM4 (Welsh)"
                 }
+            }
+        ],
+        "incl": [
+            {
+                "name": "base",
+                "lang": "en"
             }
         ]
     },

--- a/test/test_bilingual.py
+++ b/test/test_bilingual.py
@@ -14,6 +14,14 @@ class TestBilingual(unittest.TestCase):
         self.assertEqual(data.english(), 'en')
         self.assertEqual(data.welsh(), 'en')
 
+        data = Bilingual('en', '', default_to_english=True)
+        self.assertEqual(data.english(), 'en')
+        self.assertEqual(data.welsh(), 'en')
+
+        data = Bilingual('en', '', default_to_english=False)
+        self.assertEqual(data.english(), 'en')
+        self.assertEqual(data.welsh(), None)
+
     def test_bilingual_dict(self):
         data = BilingualDict({
             'lang': Bilingual('english', 'welsh'),

--- a/util/README.md
+++ b/util/README.md
@@ -1,0 +1,2 @@
+This directory contains scripts that are benefical during development
+and are not intended for general usage.

--- a/util/compare_servers.py
+++ b/util/compare_servers.py
@@ -1,0 +1,170 @@
+"""
+Check that datasets on two different instances on cantabular-metadata are the same.
+
+Script leverages the unittest infrastructure and validates that the datasets and variables
+on two separate instances of cantabular-metadata are the same. The dataset and variable names
+are identified by parsing CSV metadata source files.
+
+Environment variables can be used to set the CSV files directory and the URLs of the metadata
+servers.
+
+The tests are split into a number of suites and there are individual tests for English and
+Welsh versions.
+
+Some examples of running tests are shown below:
+
+    Run all tests:
+    python3 compare_servers.py
+    OR
+    python3 compare_servers.py
+
+    Run only Welsh tests:
+    python3 compare_servers.py DatasetTests CatLabelTests VariableTests -k _cy_
+
+
+    Run only English tests in CatLabelTests suite:
+    python3 compare_servers.py CatLabelTests -k _en_
+"""
+
+import csv
+import json
+import unittest
+import os
+import requests
+
+CSV_FILES_DIR = os.environ.get('CTB_TEST_CSV_FILES_DIR', './')
+SERVER1_URL = os.environ.get('CTB_TEST_SERVER1_URL', 'http://127.0.0.1:8493/graphql')
+SERVER2_URL = os.environ.get('CTB_TEST_SERVER2_URL', 'http://127.0.0.2:8493/graphql')
+
+DATASET_QUERY = """
+query($dataset: String!, $lang: String!) {
+ dataset(name: $dataset, lang: $lang) {
+   all
+   description
+   label
+   name
+ }
+}
+"""
+
+VARIABLE_QUERY = """
+query($variables: [String!]!, $lang: String!) {
+ dataset(name: "base", lang: $lang) {
+   vars(names: $variables) {
+     name
+     label
+     description
+     all
+   }
+ }
+}
+"""
+
+CAT_LABELS_QUERY = """
+query($variables: [String!]!, $lang: String!) {
+ dataset(name: "base", lang: $lang) {
+   vars(names: $variables) {
+     catLabels
+   }
+ }
+}
+"""
+
+def get_variables():
+    """
+    Identify all the Cantabular variables from a set of CSV metadata files.
+
+    Cantabular variable names are the set of Codebook_Mnemonic values from Category_Mapping.csv
+    along with the Variable_Mnemonic values from Variable.csv for geographic variables.
+    """
+    variables = set()
+    with open(os.path.join(CSV_FILES_DIR, 'Category_Mapping.csv'), encoding='utf-8') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            variables.add(row['Codebook_Mnemonic'])
+
+    with open(os.path.join(CSV_FILES_DIR, 'Variable.csv'), encoding='utf-8') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            if row['Variable_Type_Code'] == 'GEOG':
+                variables.add(row['Variable_Mnemonic'])
+
+    return sorted(list(variables))
+
+
+def get_datasets():
+    """
+    Identify all the Cantabular datasets from a set of CSV metadata files.
+
+    Cantabular dataset names are the set of Database_Mnemonic values from Databases.csv.
+    """
+    datasets = []
+    with open(os.path.join(CSV_FILES_DIR, 'Database.csv'), encoding='utf-8') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            datasets.append(row['Database_Mnemonic'])
+
+    return sorted(datasets)
+
+
+class TestsContainer(unittest.TestCase):
+    """TestsContainer holds dynamically created unit test cases."""
+
+    longMessage = True
+
+    def query(self, url, graphql_query, graphql_variables):
+        """Perform a GraphQL query and return the response."""
+        http_resp = requests.post(url,
+                                  data={'query': graphql_query,
+                                        'variables': json.dumps(graphql_variables)})
+        http_resp.raise_for_status()
+        resp = http_resp.json()
+        self.assertNotIn('errors', resp)
+        return resp
+
+
+class DatasetTests(TestsContainer):
+    """Tests that compare datasets."""
+
+
+class VariableTests(TestsContainer):
+    """Tests that compare variables."""
+
+
+class CatLabelTests(TestsContainer):
+    """Tests that compare category labels for a variable."""
+
+
+def make_test_function(graphql_query, graphql_variables):
+    """Make a test function and add it to the TestsContainer class."""
+    def test(self):
+        resp1 = self.query(SERVER1_URL, graphql_query, graphql_variables)
+        resp2 = self.query(SERVER2_URL, graphql_query, graphql_variables)
+        self.assertDictEqual(resp1, resp2)
+    return test
+
+
+if __name__ == '__main__':
+    for dataset in get_datasets():
+        test_func = make_test_function(DATASET_QUERY, {'dataset': dataset, 'lang': 'en'})
+        setattr(DatasetTests, f'test_en_dataset{dataset}', test_func)
+
+        test_func = make_test_function(DATASET_QUERY, {'dataset': dataset, 'lang': 'cy'})
+        setattr(DatasetTests, f'test_cy_dataset{dataset}', test_func)
+
+    for variable in get_variables():
+        test_func = make_test_function(VARIABLE_QUERY, {'variables': [variable], 'lang': 'en'})
+        setattr(VariableTests, f'test_en_variable_{variable}', test_func)
+
+        test_func = make_test_function(VARIABLE_QUERY, {'variables': [variable], 'lang': 'cy'})
+        setattr(VariableTests, f'test_cy_variable_{variable}', test_func)
+
+        test_func = make_test_function(CAT_LABELS_QUERY, {'variables': [variable], 'lang': 'en'})
+        setattr(CatLabelTests, f'test_en_variable_{variable}', test_func)
+
+        test_func = make_test_function(CAT_LABELS_QUERY, {'variables': [variable], 'lang': 'cy'})
+        setattr(CatLabelTests, f'test_cy_variable_{variable}', test_func)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The English labels for variable categories can be obtained from the codebook that is used when building a Cantabular dataset. These labels are exposed by `cantabular-server`.  

`cantabular-api-ext` combines metadata from `cantabular-server` and `cantabular-metadata`. Certain fields (including category labels) may be available from both sources and can be different. When they are different `cantabular-api-ext` selects the values from `cantabular-metadata`, allowing values from the dataset to be dynamically overridden.

Up until now the English category labels have not been included in the metadata served by `cantabular-metadata` as the data was viewed as redundant and some variables have a large number of categories.

This PR includes the English labels so as category labels can be amended without rebuilding Cantabular datasets.

Welsh datasets now include the English version of the dataset via the `incl` functionality. Specifically this avoids replicating the labels for geographic areas which do not have a Welsh translation in the Welsh JSON. A test utility has been included to ensure that there were no unintended consequences of this change.

Two instances of `cantabular-metadata` were started. One had metadata built from the `master` branch. The second had metadata from this branch. The metadata for each dataset and variable (excluding the category labels) was obtained from both servers, compared and found to be consistent:  
```
$ CTB_TEST_CSV_FILES_DIR=../ons-2021-census-metadata/ python3 util/compare_servers.py VariableTests DatasetTests
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 1246 tests in 2.891s

OK
```
