### PR TITLE
Normalise timestamps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,63 +35,63 @@ Basic logging will be displayed by default, including the number of high-level C
 objects loaded and the name of the output files.
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/ -g test/testdata/geography/geography.csv -o ctb_metadata_files/
-t=2022-12-14 15:24:57,714 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
-t=2022-12-14 15:24:57,714 lvl=INFO msg=CSV source directory: test/testdata/
-t=2022-12-14 15:24:57,714 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
-t=2022-12-14 15:24:57,715 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
-t=2022-12-14 15:24:57,715 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
-t=2022-12-14 15:24:57,715 lvl=INFO msg=Dropped non public classification: GEO_PRIV
-t=2022-12-14 15:24:57,715 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
-t=2022-12-14 15:24:57,716 lvl=INFO msg=Loaded metadata for 4 Cantabular datasets
-t=2022-12-14 15:24:57,716 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
-t=2022-12-14 15:24:57,716 lvl=INFO msg=Loaded metadata for 6 Cantabular tables
-t=2022-12-14 15:24:57,716 lvl=INFO msg=Loaded service metadata
-t=2022-12-14 15:24:57,716 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
-t=2022-12-14 15:24:57,717 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_dataset-md_20221214-1.json
-t=2022-12-14 15:24:57,718 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_tables-md_20221214-1.json
-t=2022-12-14 15:24:57,718 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_service-md_20221214-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=CSV source directory: test/testdata/
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public classification: GEO_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 4 Cantabular datasets
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 6 Cantabular tables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded service metadata
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_dataset-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_tables-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_service-md_20220101-1.json
 ```
 
 More detailed information can be obtained by running with a `-l DEBUG` flag e.g.:
 
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/ -g test/testdata/geography/geography.csv -o ctb_metadata_files/ -l DEBUG
-t=2022-12-14 15:25:47,524 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
-t=2022-12-14 15:25:47,525 lvl=INFO msg=CSV source directory: test/testdata/
-t=2022-12-14 15:25:47,525 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
-t=2022-12-14 15:25:47,525 lvl=DEBUG msg=Creating classification for geographic variable: GEO1
-t=2022-12-14 15:25:47,525 lvl=DEBUG msg=Creating classification for geographic variable: GEO2
-t=2022-12-14 15:25:47,525 lvl=DEBUG msg=Creating classification for geographic variable: GEO_PRIV
-t=2022-12-14 15:25:47,526 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS1
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS2
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS3
-t=2022-12-14 15:25:47,526 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS4
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS5
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS4A
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular variable: GEO1
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular variable: GEO2
-t=2022-12-14 15:25:47,526 lvl=INFO msg=Dropped non public classification: GEO_PRIV
-t=2022-12-14 15:25:47,526 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB1
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB2
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB3
-t=2022-12-14 15:25:47,526 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB_TAB
-t=2022-12-14 15:25:47,526 lvl=INFO msg=Loaded metadata for 4 Cantabular datasets
-t=2022-12-14 15:25:47,527 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS1
-t=2022-12-14 15:25:47,527 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS2
-t=2022-12-14 15:25:47,527 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS3
-t=2022-12-14 15:25:47,527 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
-t=2022-12-14 15:25:47,527 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS4
-t=2022-12-14 15:25:47,527 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS_TAB
-t=2022-12-14 15:25:47,527 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS_TAB2
-t=2022-12-14 15:25:47,527 lvl=INFO msg=Loaded metadata for 6 Cantabular tables
-t=2022-12-14 15:25:47,527 lvl=INFO msg=Loaded service metadata
-t=2022-12-14 15:25:47,527 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
-t=2022-12-14 15:25:47,528 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_dataset-md_20221214-1.json
-t=2022-12-14 15:25:47,529 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_tables-md_20221214-1.json
-t=2022-12-14 15:25:47,529 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_service-md_20221214-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=CSV source directory: test/testdata/
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Creating classification for geographic variable: GEO1
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Creating classification for geographic variable: GEO2
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Creating classification for geographic variable: GEO_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS1
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS2
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS3
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS4
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS5
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: CLASS4A
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: GEO1
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: GEO2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public classification: GEO_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB1
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB2
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB3
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: DB_TAB
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 4 Cantabular datasets
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS1
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS2
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS3
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS4
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS_TAB
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: DS_TAB2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 6 Cantabular tables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded service metadata
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_dataset-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_tables-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_service-md_20220101-1.json
 ```
 
 Output file names
@@ -121,21 +121,21 @@ arguments as described in the help text for `ons_csv_to_ctb_json_main.py`:
 For example:
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/ -g test/testdata/geography/geography.csv -o ctb_metadata_files/ -p t -m test -b 42
-t=2022-12-14 15:26:29,585 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
-t=2022-12-14 15:26:29,585 lvl=INFO msg=CSV source directory: test/testdata/
-t=2022-12-14 15:26:29,585 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
-t=2022-12-14 15:26:29,587 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
-t=2022-12-14 15:26:29,587 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
-t=2022-12-14 15:26:29,587 lvl=INFO msg=Dropped non public classification: GEO_PRIV
-t=2022-12-14 15:26:29,587 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
-t=2022-12-14 15:26:29,587 lvl=INFO msg=Loaded metadata for 4 Cantabular datasets
-t=2022-12-14 15:26:29,588 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
-t=2022-12-14 15:26:29,588 lvl=INFO msg=Loaded metadata for 6 Cantabular tables
-t=2022-12-14 15:26:29,588 lvl=INFO msg=Loaded service metadata
-t=2022-12-14 15:26:29,588 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
-t=2022-12-14 15:26:29,589 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/t_cantabm_v10-2-2_test_dataset-md_20221214-42.json
-t=2022-12-14 15:26:29,589 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/t_cantabm_v10-2-2_test_tables-md_20221214-42.json
-t=2022-12-14 15:26:29,589 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/t_cantabm_v10-2-2_test_service-md_20221214-42.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=CSV source directory: test/testdata/
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public classification: GEO_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 4 Cantabular datasets
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 6 Cantabular tables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded service metadata
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/t_cantabm_v10-2-2_test_dataset-md_20220101-42.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/t_cantabm_v10-2-2_test_tables-md_20220101-42.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/t_cantabm_v10-2-2_test_service-md_20220101-42.json
 ```
 
 Using data with errors
@@ -150,57 +150,57 @@ This repository contains some test data that is full of errors. It can be used t
 of the `--best-effort` flag as shown below:
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/best_effort  -o ctb_metadata_files/ -m best-effort --best-effort
-t=2022-12-14 15:27:14,776 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
-t=2022-12-14 15:27:14,776 lvl=INFO msg=CSV source directory: test/testdata/best_effort
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Variable.csv:4 Geography_Hierarchy_Order value of 10 specified for both GEO2 and GEO1
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Variable.csv:8 no Geography_Hierarchy_Order specified for geographic variable: GEO4
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Variable.csv:8 using 0 for Geography_Hierarchy_Order
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:3 no value supplied for required field Variable_Mnemonic
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:3 dropping record
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:4 duplicate value CLASS1 for Classification_Mnemonic
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:4 dropping record
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:5 invalid value x for Number_Of_Category_Items
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:5 ignoring field Number_Of_Category_Items
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:3 different Codebook_Mnemonic values specified for classification CLASS1: CLASS1 (Codebook A) and CLASS1 (Codebook)
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:4 CLASS1 (Codebook) is Codebook_Mnemonic for both CLASS1 and CLASS3
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:4 ignoring field Codebook_Mnemonic
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:5 CLASS1 is an invalid Codebook_Mnemonic for classification CLASS4 as it is already the Classification_Mnemonic for another classification
-t=2022-12-14 15:27:14,777 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:5 ignoring field Codebook_Mnemonic
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Category.csv Unexpected number of categories for CLASS1: expected 4 but found 1
-t=2022-12-14 15:27:14,778 lvl=INFO msg=No geography file specified
-t=2022-12-14 15:27:14,778 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Database_Variable.csv Lowest_Geog_Variable_Flag set on GEO3 and GEO1 for database DB1
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Database_Variable.csv GEO1 is unknown Classification_Mnemonic for Variable_Mnemonic VAR1
-t=2022-12-14 15:27:14,778 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:4 duplicate value combo DS1/VAR1 for Dataset_Mnemonic/Variable_Mnemonic
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:4 dropping record
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 Lowest_Geog_Variable_Flag set on non-geographic variable VAR1 for dataset DS1
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 Processing_Priority not specified for classification CLASS1 in dataset DS1
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 using 0 for Processing_Priority
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:3 Classification_Mnemonic must not be specified for geographic variable GEO1 in dataset DS1
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:3 Processing_Priority must not be specified for geographic variable GEO1 in dataset DS1
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:5 Lowest_Geog_Variable_Flag set on variable GEO2 and GEO1 for dataset DS1
-t=2022-12-14 15:27:14,778 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:5 DS1 has geographic variable GEO2 that is not in database DB1
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:7 Classification must be specified for non-geographic VAR2 in dataset DS1
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:7 dropping record
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:8 Invalid classification CLASS1 specified for variable VAR3 in dataset DS1
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:8 dropping record
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:9 DS2 has classification CLASS3 that is not in database DB1
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:10 DS4 has Database_Mnemonic DB_TAB which has invalid Database_Type_Code: AGGDATA
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv Invalid processing_priorities [0] for dataset DS1
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:4 DS3 has no associated classifications or geographic variable
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:4 dropping record
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:5 DS4 has an empty value for Destination_Pre_Built_Database_Mnemonic and has classifications from multiple databases: ['DB2', 'DB_TAB']
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:6 DS5 has Destination_Pre_Built_Database_Mnemonic DB1 which has invalid Database_Type_Code: MICRODATA
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:6 dropping record
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:8 DS7 has different observation type AMT from other datasets in database DB_TAB: None
-t=2022-12-14 15:27:14,779 lvl=INFO msg=Loaded metadata for 5 Cantabular tables
-t=2022-12-14 15:27:14,779 lvl=INFO msg=Loaded service metadata
-t=2022-12-14 15:27:14,779 lvl=WARNING msg=27 errors were encountered during processing
-t=2022-12-14 15:27:14,779 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
-t=2022-12-14 15:27:14,780 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_best-effort_dataset-md_20221214-1.json
-t=2022-12-14 15:27:14,780 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_best-effort_tables-md_20221214-1.json
-t=2022-12-14 15:27:14,780 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_best-effort_service-md_20221214-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=CSV source directory: test/testdata/best_effort
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Variable.csv:4 Geography_Hierarchy_Order value of 10 specified for both GEO2 and GEO1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Variable.csv:8 no Geography_Hierarchy_Order specified for geographic variable: GEO4
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Variable.csv:8 using 0 for Geography_Hierarchy_Order
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:3 no value supplied for required field Variable_Mnemonic
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:3 dropping record
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:4 duplicate value CLASS1 for Classification_Mnemonic
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:4 dropping record
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:5 invalid value x for Number_Of_Category_Items
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Classification.csv:5 ignoring field Number_Of_Category_Items
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:3 different Codebook_Mnemonic values specified for classification CLASS1: CLASS1 (Codebook A) and CLASS1 (Codebook)
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:4 CLASS1 (Codebook) is Codebook_Mnemonic for both CLASS1 and CLASS3
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:4 ignoring field Codebook_Mnemonic
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:5 CLASS1 is an invalid Codebook_Mnemonic for classification CLASS4 as it is already the Classification_Mnemonic for another classification
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Category_Mapping.csv:5 ignoring field Codebook_Mnemonic
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Category.csv Unexpected number of categories for CLASS1: expected 4 but found 1
+t=2022-01-01 00:00:00,000 lvl=INFO msg=No geography file specified
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Database_Variable.csv Lowest_Geog_Variable_Flag set on GEO3 and GEO1 for database DB1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Database_Variable.csv GEO1 is unknown Classification_Mnemonic for Variable_Mnemonic VAR1
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 3 Cantabular datasets
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:4 duplicate value combo DS1/VAR1 for Dataset_Mnemonic/Variable_Mnemonic
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:4 dropping record
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 Lowest_Geog_Variable_Flag set on non-geographic variable VAR1 for dataset DS1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 Processing_Priority not specified for classification CLASS1 in dataset DS1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:2 using 0 for Processing_Priority
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:3 Classification_Mnemonic must not be specified for geographic variable GEO1 in dataset DS1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:3 Processing_Priority must not be specified for geographic variable GEO1 in dataset DS1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:5 Lowest_Geog_Variable_Flag set on variable GEO2 and GEO1 for dataset DS1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:5 DS1 has geographic variable GEO2 that is not in database DB1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:7 Classification must be specified for non-geographic VAR2 in dataset DS1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:7 dropping record
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:8 Invalid classification CLASS1 specified for variable VAR3 in dataset DS1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:8 dropping record
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:9 DS2 has classification CLASS3 that is not in database DB1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv:10 DS4 has Database_Mnemonic DB_TAB which has invalid Database_Type_Code: AGGDATA
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset_Variable.csv Invalid processing_priorities [0] for dataset DS1
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:4 DS3 has no associated classifications or geographic variable
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:4 dropping record
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:5 DS4 has an empty value for Destination_Pre_Built_Database_Mnemonic and has classifications from multiple databases: ['DB2', 'DB_TAB']
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:6 DS5 has Destination_Pre_Built_Database_Mnemonic DB1 which has invalid Database_Type_Code: MICRODATA
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:6 dropping record
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=Reading test/testdata/best_effort/Dataset.csv:8 DS7 has different observation type AMT from other datasets in database DB_TAB: None
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 5 Cantabular tables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded service metadata
+t=2022-01-01 00:00:00,000 lvl=WARNING msg=27 errors were encountered during processing
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_best-effort_dataset-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_best-effort_tables-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_best-effort_service-md_20220101-1.json
 ```
 
 Many lines contain strings such as `test/testdata/best_effort/Dataset.csv:4` this means that an error has been detected
@@ -223,20 +223,20 @@ datasets with a `Dataset_Mnemonic` beginning with **TS** are processed.
 
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/dataset_filter/ -o ctb_metadata_files/ --dataset-filter TS
-t=2022-12-14 15:27:56,339 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
-t=2022-12-14 15:27:56,339 lvl=INFO msg=CSV source directory: test/testdata/dataset_filter/
-t=2022-12-14 15:27:56,339 lvl=INFO msg=Dataset filter: TS
-t=2022-12-14 15:27:56,340 lvl=INFO msg=No geography file specified
-t=2022-12-14 15:27:56,340 lvl=INFO msg=Loaded metadata for 1 Cantabular variables
-t=2022-12-14 15:27:56,340 lvl=INFO msg=Loaded metadata for 1 Cantabular datasets
-t=2022-12-14 15:27:56,340 lvl=INFO msg=Reading test/testdata/dataset_filter/Dataset.csv dropped 1 records related to datasets with Dataset_Mnemonics that do not start with one of: ['TS']
-t=2022-12-14 15:27:56,340 lvl=INFO msg=Reading test/testdata/dataset_filter/Dataset_Variable.csv dropped 1 records related to datasets with Dataset_Mnemonics that do not start with one of: ['TS']
-t=2022-12-14 15:27:56,340 lvl=INFO msg=Loaded metadata for 1 Cantabular tables
-t=2022-12-14 15:27:56,340 lvl=INFO msg=Loaded service metadata
-t=2022-12-14 15:27:56,340 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
-t=2022-12-14 15:27:56,340 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_dataset-md_20221214-1.json
-t=2022-12-14 15:27:56,341 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_tables-md_20221214-1.json
-t=2022-12-14 15:27:56,341 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_service-md_20221214-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=CSV source directory: test/testdata/dataset_filter/
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dataset filter: TS
+t=2022-01-01 00:00:00,000 lvl=INFO msg=No geography file specified
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 1 Cantabular variables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 1 Cantabular datasets
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Reading test/testdata/dataset_filter/Dataset.csv dropped 1 records related to datasets with Dataset_Mnemonics that do not start with one of: ['TS']
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Reading test/testdata/dataset_filter/Dataset_Variable.csv dropped 1 records related to datasets with Dataset_Mnemonics that do not start with one of: ['TS']
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 1 Cantabular tables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded service metadata
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_dataset-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_tables-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_unknown-metadata-version_service-md_20220101-1.json
 ```
 
 Using 2011 census teaching file metadata
@@ -252,43 +252,43 @@ can be found in the `sample_2011` directory.
 Use this command to convert the files to JSON (with debugging enabled):
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i sample_2011/ -g sample_2011/geography.csv -o ctb_metadata_files/ -m 2001-sample -l DEBUG
-t=2022-12-14 15:28:35,123 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
-t=2022-12-14 15:28:35,124 lvl=INFO msg=CSV source directory: sample_2011/
-t=2022-12-14 15:28:35,124 lvl=INFO msg=Geography file: sample_2011/geography.csv
-t=2022-12-14 15:28:35,125 lvl=DEBUG msg=Creating classification for geographic variable: Region
-t=2022-12-14 15:28:35,125 lvl=DEBUG msg=Creating classification for geographic variable: Country
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Residence Type
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Family Composition
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Population Base
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Sex
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Age
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Marital Status
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Student
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Country of Birth
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Health
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Ethnic Group
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Religion
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Economic Activity
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Occupation
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Industry
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Hours worked per week
-t=2022-12-14 15:28:35,126 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Approximated Social Grade
-t=2022-12-14 15:28:35,127 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Region
-t=2022-12-14 15:28:35,127 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Country
-t=2022-12-14 15:28:35,127 lvl=INFO msg=Loaded metadata for 18 Cantabular variables
-t=2022-12-14 15:28:35,127 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: Teaching-Dataset
-t=2022-12-14 15:28:35,127 lvl=INFO msg=Loaded metadata for 1 Cantabular datasets
-t=2022-12-14 15:28:35,127 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC2101EW
-t=2022-12-14 15:28:35,127 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC1117EW
-t=2022-12-14 15:28:35,127 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC2107EW
-t=2022-12-14 15:28:35,127 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC6107EW
-t=2022-12-14 15:28:35,127 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC6112EW
-t=2022-12-14 15:28:35,128 lvl=INFO msg=Loaded metadata for 5 Cantabular tables
-t=2022-12-14 15:28:35,128 lvl=INFO msg=Loaded service metadata
-t=2022-12-14 15:28:35,128 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
-t=2022-12-14 15:28:35,130 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_2001-sample_dataset-md_20221214-1.json
-t=2022-12-14 15:28:35,131 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_2001-sample_tables-md_20221214-1.json
-t=2022-12-14 15:28:35,131 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_2001-sample_service-md_20221214-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=CSV source directory: sample_2011/
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Geography file: sample_2011/geography.csv
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Creating classification for geographic variable: Region
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Creating classification for geographic variable: Country
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Residence Type
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Family Composition
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Population Base
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Sex
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Age
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Marital Status
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Student
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Country of Birth
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Health
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Ethnic Group
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Religion
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Economic Activity
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Occupation
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Industry
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Hours worked per week
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Approximated Social Grade
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Region
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular variable: Country
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 18 Cantabular variables
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular dataset: Teaching-Dataset
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 1 Cantabular datasets
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC2101EW
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC1117EW
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC2107EW
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC6107EW
+t=2022-01-01 00:00:00,000 lvl=DEBUG msg=Loaded metadata for Cantabular table: LC6112EW
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 5 Cantabular tables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded service metadata
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Output files will be written in Cantabular 10.2.2 format
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v10-2-2_2001-sample_dataset-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written table metadata file to: ctb_metadata_files/cantabm_v10-2-2_2001-sample_tables-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v10-2-2_2001-sample_service-md_20220101-1.json
 ```
 
 Load the JSON files with cantabular-metadata
@@ -298,7 +298,7 @@ To load the generated JSON files into `cantabular-metadata` (version 10.2.2) run
 commands, substituting the file names and paths as appropriate:
 ```
 cd ctb_metadata_files
-CANTABULAR_METADATA_GRAPHQL_TYPES_FILE=metadata.graphql CANTABULAR_METADATA_SERVICE_FILE=cantabm_v10-2-2_unknown-metadata-version_service-md_20221214-1.json CANTABULAR_METADATA_DATASET_FILES=cantabm_v10-2-2_unknown-metadata-version_dataset-md_20221214-1.json CANTABULAR_METADATA_TABLE_FILES=cantabm_v10-2-2_unknown-metadata-version_tables-md_20221214-1.json <PATH_TO_BINARY>/cantabular-metadata
+CANTABULAR_METADATA_GRAPHQL_TYPES_FILE=metadata.graphql CANTABULAR_METADATA_SERVICE_FILE=cantabm_v10-2-2_unknown-metadata-version_service-md_20220101-1.json CANTABULAR_METADATA_DATASET_FILES=cantabm_v10-2-2_unknown-metadata-version_dataset-md_20220101-1.json CANTABULAR_METADATA_TABLE_FILES=cantabm_v10-2-2_unknown-metadata-version_tables-md_20220101-1.json <PATH_TO_BINARY>/cantabular-metadata
 ```
 
 The metadata can be queried via a GraphQL interface. By default this is accessible at:
@@ -337,20 +337,20 @@ will be reflected in the output filenames, but `10.2.2` format will be used.
 To generate version 9.2.0 compatible files from the test data use the following command:
 ```
 > python3 bin/ons_csv_to_ctb_json_main.py -i test/testdata/ -g test/testdata/geography/geography.csv -o ctb_metadata_files/ -v 9.2.0
-t=2022-12-14 15:38:00,213 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
-t=2022-12-14 15:38:00,213 lvl=INFO msg=CSV source directory: test/testdata/
-t=2022-12-14 15:38:00,213 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
-t=2022-12-14 15:38:00,214 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
-t=2022-12-14 15:38:00,214 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
-t=2022-12-14 15:38:00,214 lvl=INFO msg=Dropped non public classification: GEO_PRIV
-t=2022-12-14 15:38:00,214 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
-t=2022-12-14 15:38:00,215 lvl=INFO msg=Loaded metadata for 4 Cantabular datasets
-t=2022-12-14 15:38:00,215 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
-t=2022-12-14 15:38:00,215 lvl=INFO msg=Loaded metadata for 6 Cantabular tables
-t=2022-12-14 15:38:00,215 lvl=INFO msg=Loaded service metadata
-t=2022-12-14 15:38:00,215 lvl=INFO msg=Output files will be written in Cantabular 9.2.0 format
-t=2022-12-14 15:38:00,225 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v9-2-0_unknown-metadata-version_dataset-md_20221214-1.json
-t=2022-12-14 15:38:00,225 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v9-2-0_unknown-metadata-version_service-md_20221214-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=ons_csv_to_ctb_json_main.py version 1.3.2
+t=2022-01-01 00:00:00,000 lvl=INFO msg=CSV source directory: test/testdata/
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Geography file: test/testdata/geography/geography.csv
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Reading test/testdata/geography/geography.csv: found Welsh labels for unknown classification: OTHER
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public classification: CLASS_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public classification: GEO_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 8 Cantabular variables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 4 Cantabular datasets
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Dropped non public ONS Dataset: DS_PRIV
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded metadata for 6 Cantabular tables
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Loaded service metadata
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Output files will be written in Cantabular 9.2.0 format
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written dataset metadata file to: ctb_metadata_files/cantabm_v9-2-0_unknown-metadata-version_dataset-md_20220101-1.json
+t=2022-01-01 00:00:00,000 lvl=INFO msg=Written service metadata file to: ctb_metadata_files/cantabm_v9-2-0_unknown-metadata-version_service-md_20220101-1.json
 ```
 
 No tables metadata file is produced. The tables data is embedded in the service metadata file.
@@ -364,5 +364,5 @@ To load the generated JSON files into `cantabular-metadata` (version 9.2.0) run 
 commands, substituting the file names and paths as appropriate:
 ```
 cd ctb_metadata_files
-<PATH_TO_9.2.0_BINARY>/cantabular-metadata metadata_9_2_0.graphql cantabm_v9-2-0_unknown-metadata-version_service-md_20221214-1.json cantabm_v9-2-0_unknown-metadata-version_dataset-md_20221214-1.json
+<PATH_TO_9.2.0_BINARY>/cantabular-metadata metadata_9_2_0.graphql cantabm_v9-2-0_unknown-metadata-version_service-md_20220101-1.json cantabm_v9-2-0_unknown-metadata-version_dataset-md_20220101-1.json
 ```

--- a/util/normalise_readme.sh
+++ b/util/normalise_readme.sh
@@ -1,0 +1,7 @@
+# This is a utility script for normalising the timestamps in README.md
+# It is used during development
+# Run from base directory:
+# ./util/normalise_readme.sh
+sed -i -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}/2022-01-01 00:00:00,000/g' README.md
+sed -i -r 's/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}/2022-01-01T00:00:00.000000/g' README.md
+sed -i -r 's/_[0-9]{8}-/_20220101-/g' README.md


### PR DESCRIPTION
Timestamps now all have the same value and will not change. This makes it easier to see important changes in the README.md file during code review.

Also included script used to normalise the file so that it can be used in future.