### PR TITLE
Allow multiple -g flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Using test data
 The `test/testdata` directory contains some sample CSV files that are used as part of continuous
 integration testing. They contain dummy data that are intended to exercise the capabilities of the
 software. Category information for geographic variables is supplied in files found in the
-`test/testdata/geography` directory. Alternatively a comma separated list of individual geography
-lookup files may be specified using the `-g` option.
+`test/testdata/geography` directory. Alternatively individual geography lookup files may be
+specified using the `-g` option e.g. `-g file1.csv -g file2.csv`.
 The data can be used to verify the operation of `ons_csv_to_ctb_json_main.py`.
 
 To convert the source CSV files to JSON files in `ctb_metadata_files/` run:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,8 @@ Release Notes
 1.3.3
 -----
 
-- Support multiple geography lookup files. Files can be supplied as a comma-separated list using
-  the `-g` option. Alternatively a geography folder can be specifed using the new `-d` option.
+- Support multiple geography lookup files. Files can be supplied using the `-g` option, with
+  one `-g` option per file. Alternatively a geography folder can be specifed using the new `-d` option.
 - Expose `Cantabular_Public_Flag` for each variable on a per-dataset basis.
 
 1.3.2

--- a/bin/ons_csv_to_ctb_json_main.py
+++ b/bin/ons_csv_to_ctb_json_main.py
@@ -81,11 +81,13 @@ def main():
     # geography file was supported. The list of files could be quite long, so also adding
     # the -d option.
     group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument('-g', '--geography-files',
+    group.add_argument('-g', '--geography-file',
                        type=str,
+                       action='append',
                        required=False,
-                       help='Names of CSV files containing category codes and names for '
-                            'geographic variables, supplied as a comma-separated list')
+                       help='Name of CSV file containing category codes and names for '
+                            'geographic variables. Multiple files can be specified using separate '
+                            '-g options.')
 
     group.add_argument('-d', '--geography-dir',
                        type=str,
@@ -161,8 +163,8 @@ def main():
     logging.info(f'{Path(__file__).name} version {SCRIPT_VERSION}')
     logging.info(f'CSV source directory: {args.input_dir}')
     geography_files = []
-    if args.geography_files:
-        geography_files = [fn.strip() for fn in args.geography_files.split(',')]
+    if args.geography_file:
+        geography_files = [fn.strip() for fn in args.geography_file]
         seen = set()
         dupes = [fn for fn in geography_files if fn in seen or seen.add(fn)]
         if dupes:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -93,10 +93,9 @@ class TestIntegration(unittest.TestCase):
         geo_dir = os.path.join(file_dir, 'geography')
 
         geo1_file = os.path.join(geo_dir, 'geography1.csv')
-        dupe_geo_files = ','.join([geo1_file]*2)
         expected_error = f"Some geography filenames are specified multiple times: \['{geo1_file}'\]"
         with unittest.mock.patch('sys.argv', ['test', '-i', input_dir, '-o', output_dir,
-                                              '-g', dupe_geo_files]):
+                                              '-g', geo1_file, '-g', geo1_file]):
             with self.assertRaisesRegex(ValueError, expected_error):
                 ons_csv_to_ctb_json_main.main()
 
@@ -121,9 +120,10 @@ class TestIntegration(unittest.TestCase):
         file_dir = pathlib.Path(__file__).parent.resolve()
         input_dir = os.path.join(file_dir, 'testdata')
         output_dir = os.path.join(file_dir, 'out')
-        geo_files = f'{os.path.join(input_dir, "geography/geography1.csv")} , {os.path.join(input_dir, "geography/geography2.csv")}'
+        geo1_file = os.path.join(input_dir, 'geography/geography1.csv')
+        geo2_file = os.path.join(input_dir, 'geography/geography2.csv')
         geo_dir = os.path.join(input_dir, 'geography')
-        for args in [['test', '-i', input_dir, '-o', output_dir, '-g', geo_files], ['test', '-i', input_dir, '-o', output_dir, '-d', geo_dir]]:
+        for args in [['test', '-i', input_dir, '-o', output_dir, '-g', geo1_file, '-g', geo2_file], ['test', '-i', input_dir, '-o', output_dir, '-d', geo_dir]]:
             with self.assertLogs(level='INFO') as cm:
                 with unittest.mock.patch('sys.argv', args):
                     ons_csv_to_ctb_json_main.main()


### PR DESCRIPTION
Support "-g file1.csv -g file2.csv" instead of "-g file1.csv,file2.csv"